### PR TITLE
Change to std/http

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ The endpoint replies to any path to allow easier control of the output file name
 
 ## Running Locally
 
-Although this project is indented to run with Deno Deploy, it may be ran anywhere with [Deno](https://deno.land) and [deployctl](https://deno.com/deploy/docs/deployctl/)
+Although this project is indented to run with Deno Deploy, it may be ran anywhere with [Deno](https://deno.land)
 
 ```bash
-deployctl run mod.ts
+deno run --allow-net=:8000 mod.ts
 ```
 
 ## Running In Development Mode
-`deployctl` allows running in 'watch' mode, automatically restarting when files are changed
+`deno` allows running in 'watch' mode, automatically restarting when files are changed
 ```bash
-deployctl run --watch mod.ts
+deno --allow-net=:8000 run --watch mod.ts
 ```
 
 ## Usage

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,3 @@
-export { vCard } from "https://deno.land/x/vcard@v1.0.6d/mod.ts"
+export { listenAndServe } from "https://deno.land/std@0.111.0/http/server.ts";
+export type { ServerRequest } from "https://deno.land/std@0.111.0"
+export { vCard } from "https://deno.land/x/vcard@v1.0.6d/mod.ts";

--- a/errorResponse.ts
+++ b/errorResponse.ts
@@ -2,8 +2,9 @@ export function errorResponse(errorCode?:number, errorText = ""):Response{
   return new Response(errorText,
   {
     status: errorCode ? errorCode : 400,
+    statusText: errorText,
     headers: {
-      "content-type": "text/html; charset=UTF-8",
+      "content-type": "text/plain; charset=UTF-8",
     },
     
   });

--- a/errorResponse.ts
+++ b/errorResponse.ts
@@ -1,9 +1,5 @@
 export function errorResponse(errorCode?:number, errorText = ""):Response{
-  return new Response(`
-    <body style="text-align: center; font-family: Avenir, Helvetica, Arial, sans-serif">
-      <p style="color:red;">${errorText}</p>
-    </body>
-  `,
+  return new Response(errorText,
   {
     status: errorCode ? errorCode : 400,
     headers: {

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,7 @@
-
+import { listenAndServe, ServerRequest } from "./deps.ts";
 import { handleRequest } from "./handleRequest.ts";
 
-addEventListener("fetch", (event) => {
-  event.respondWith(handleRequest(event.request));
+
+listenAndServe(":8000", (request: ServerRequest)=>{
+  return handleRequest(request);
 });


### PR DESCRIPTION
Deno Deploy is depreciating the use of `addEventListener` to handle http requests in favor of native methods.  This project is now utilizing [std/http](http://deno.land/std/http).

This change removes the need for `deployctl` to run locally.  The README has been updated with the appropriate commands